### PR TITLE
[FEATURE] Docker: dynamic default restart_policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ History
 
 - Fixuid: Add Dockerfile generation when fixuid.yml file is created or deleted
 - Docker: Add docker.reverse_proxy.certresolver setting to setup traefik certresolver globally
+- Docker: Set `docker.restart_policy` default value to `unless-stopped` if `core.env.current` is different of `dev`
 - Jsonnet : Add optional router_rule parameter to `ddb.VirtualHost` function in order to override the default `Host(hostname)`.
 For traefik, available values in the [official documentation](https://docs.traefik.io/v2.0/routing/routers/#rule)
 

--- a/ddb/feature/docker/__init__.py
+++ b/ddb/feature/docker/__init__.py
@@ -49,6 +49,7 @@ class DockerFeature(Feature):
         self._configure_defaults_port_prefix(feature_config)
         self._configure_defaults_compose_project_name(feature_config)
         self._configure_defaults_build_image_tag(feature_config)
+        self._configure_defaults_restart_policy(feature_config)
 
     @staticmethod
     def _configure_defaults_user(feature_config):
@@ -166,3 +167,12 @@ class DockerFeature(Feature):
             else:
                 build_image_tag = branch
             feature_config['build_image_tag'] = build_image_tag
+
+    @staticmethod
+    def _configure_defaults_restart_policy(feature_config):
+        restart_policy = feature_config.get('restart_policy')
+        if restart_policy is None:
+            if config.data.get("core.env.current") == "dev":
+                feature_config['restart_policy'] = 'no'
+            else:
+                feature_config['restart_policy'] = 'unless-stopped'

--- a/ddb/feature/docker/schema.py
+++ b/ddb/feature/docker/schema.py
@@ -2,6 +2,7 @@
 
 from marshmallow import fields, Schema
 
+from ddb.config import config
 from ddb.feature.schema import FeatureSchema
 
 
@@ -47,6 +48,12 @@ class DebugSchema(Schema):
     host = fields.String(required=True, default=None)  # default is set in feature _configure_defaults
 
 
+def _default_restart_policy():
+    if config.data.get("core.env.current") == "dev":
+        return "no"
+    return "unless-stopped"
+
+
 class DockerSchema(FeatureSchema):
     """
     Docker schema.
@@ -54,7 +61,7 @@ class DockerSchema(FeatureSchema):
     user = fields.Nested(UserSchema(), required=True, default=UserSchema())
     ip = fields.String(required=True, default=None)  # default is set in feature _configure_defaults
     debug = fields.Nested(DebugSchema(), default=DebugSchema())
-    restart_policy = fields.String(required=True, default="no")
+    restart_policy = fields.String(required=True, default=_default_restart_policy)
     port_prefix = fields.Integer(required=False)  # default is set in feature _configure_defaults
     registry = fields.Nested(RegistrySchema(), required=True, default=RegistrySchema())
     interface = fields.String(required=True, default="docker0")

--- a/ddb/feature/docker/schema.py
+++ b/ddb/feature/docker/schema.py
@@ -2,7 +2,6 @@
 
 from marshmallow import fields, Schema
 
-from ddb.config import config
 from ddb.feature.schema import FeatureSchema
 
 
@@ -48,12 +47,6 @@ class DebugSchema(Schema):
     host = fields.String(required=True, default=None)  # default is set in feature _configure_defaults
 
 
-def _default_restart_policy():
-    if config.data.get("core.env.current") == "dev":
-        return "no"
-    return "unless-stopped"
-
-
 class DockerSchema(FeatureSchema):
     """
     Docker schema.
@@ -61,7 +54,8 @@ class DockerSchema(FeatureSchema):
     user = fields.Nested(UserSchema(), required=True, default=UserSchema())
     ip = fields.String(required=True, default=None)  # default is set in feature _configure_defaults
     debug = fields.Nested(DebugSchema(), default=DebugSchema())
-    restart_policy = fields.String(required=True, default=_default_restart_policy)
+    restart_policy = fields.String(required=False, allow_none=True,
+                                   default=None)  # default is set in feature _configure_defaults
     port_prefix = fields.Integer(required=False)  # default is set in feature _configure_defaults
     registry = fields.Nested(RegistrySchema(), required=True, default=RegistrySchema())
     interface = fields.String(required=True, default="docker0")

--- a/tests/feature/jsonnet/test_jsonnet.data/docker_compose_traefik/ddb.ci.yml
+++ b/tests/feature/jsonnet/test_jsonnet.data/docker_compose_traefik/ddb.ci.yml
@@ -5,6 +5,7 @@ core:
     name: gli-biometrie
 docker:
   cache_from_image: True
+  restart_policy: "no"
   registry:
     name: "gfiorleans.azurecr.io"
     repository: "gli-biometrie"

--- a/tests/feature/jsonnet/test_jsonnet.data/docker_compose_traefik/ddb.prod.yml
+++ b/tests/feature/jsonnet/test_jsonnet.data/docker_compose_traefik/ddb.prod.yml
@@ -4,7 +4,6 @@ core:
   project:
     name: gli-biometrie
 docker:
-  restart_policy: "unless-stopped"
   registry:
     name: "gfiorleans.azurecr.io"
     repository: "gli-biometrie"


### PR DESCRIPTION
Docker: Set `docker.restart_policy` default value to `unless-stopped` if `core.env.current` is different of `dev` (Fix #26)