### PR TITLE
Add macos/zsh support

### DIFF
--- a/ddb/feature/shell/__init__.py
+++ b/ddb/feature/shell/__init__.py
@@ -44,7 +44,7 @@ class ShellFeature(Feature):
     def phases(self) -> Iterable[Phase]:
         return (
             DefaultPhase("activate", "Write a shell script to be executed to activate environment"),
-            DefaultPhase("deactivatde", "Write a shell script to be executed to deactivate environment")
+            DefaultPhase("deactivate", "Write a shell script to be executed to deactivate environment")
         )
 
     @property

--- a/ddb/feature/shell/__init__.py
+++ b/ddb/feature/shell/__init__.py
@@ -44,7 +44,7 @@ class ShellFeature(Feature):
     def phases(self) -> Iterable[Phase]:
         return (
             DefaultPhase("activate", "Write a shell script to be executed to activate environment"),
-            DefaultPhase("deactivate", "Write a shell script to be executed to deactivate environment")
+            DefaultPhase("deactivatde", "Write a shell script to be executed to deactivate environment")
         )
 
     @property
@@ -68,5 +68,7 @@ class ShellFeature(Feature):
                 feature_config['shell'] = 'cmd'
             elif shell and shell.endswith('bash'):
                 feature_config['shell'] = 'bash'
+            elif shell and shell.endswith('zsh'):
+                feature_config['shell'] = 'zsh'
             else:
                 raise FeatureConfigurationAutoConfigureError(self, 'shell')


### PR DESCRIPTION
Mac OS seems to use ZSH as default shell. So, i have integrated ZSH for ShellIntegration.

Futhermore, docker for mac does not expose API as on Debian/Ubuntu/... 
So, I have added the detection of /var/run/docker.sock and set the IP to 127.0.0.1 as default value.