### PR TITLE
feat(watch): Add support for ddb.yml configuration watch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ History
 - Core: Add the `info` command which output compacted information about docker containers such as environment 
   variables, virtual host, exposed ports and binaries.
 - Fixuid: Enhance fixuid configuration when image has no entrypoint defined.
+- Config: Add support for `ddb.yml` configuration watch. If a project configuration file changes, configuration is 
+reloaded and command is runned again to update all generated files. It currently doesn't watch configuration files 
+from ~/.docker-devbox nor ~/.docker-devbox/ddb directories as it's based on `file` feature events.
 
 
 1.0.3 (2020-09-01)

--- a/ddb/action/action.py
+++ b/ddb/action/action.py
@@ -77,6 +77,11 @@ class InitializableAction(Action, ABC):  # pylint:disable=abstract-method
         Initialize method, invoked before first event binding execution.
         """
 
+    def destroy(self):
+        """
+        destroy method, invoked on shutdown.
+        """
+
 
 class WatchSupport(ABC):
     """

--- a/ddb/action/runner.py
+++ b/ddb/action/runner.py
@@ -60,11 +60,12 @@ class ActionEventBindingRunner(Generic[A], EventBindingRunner[A]):
             return True
         except Exception as exception:  # pylint:disable=broad-except
             self._handle_exception(exception)
-            if self.fail_fast:  #  TODO: Ajouter une option à la ligne de commande
+            if self.fail_fast:  # TODO: Ajouter une option à la ligne de commande
                 raise
 
         finally:
-            context.stack.pop()
+            if context.stack:
+                context.stack.pop()
 
     def _execute_action(self, *args, **kwargs):
         """

--- a/ddb/context/context.py
+++ b/ddb/context/context.py
@@ -37,7 +37,7 @@ class ContextStackItem:
                                     parameters_repr)
 
 
-class Context:
+class Context:  # pylint:disable=too-many-instance-attributes
     """
     Execution context.
     """
@@ -46,6 +46,7 @@ class Context:
         self.phase = None  # type: Optional['Phase']
         self.command = None  # type: Optional['Command']
         self.stack = []  # type: List[ContextStackItem]
+        self.watching = False  # type: bool
         self.exceptions = []  # type: List[Exception]
         self.processed_sources = dict()  # type: Dict[str, str]
         self.processed_targets = dict()  # type: Dict[str, str]

--- a/ddb/event/events.py
+++ b/ddb/event/events.py
@@ -208,9 +208,22 @@ class Phase:
         """
 
 
+class Config:
+    """
+    Phase related events.
+    """
+
+    @event("config:reloaded")
+    def reloaded(self):
+        """
+        Config has been reloaded
+        """
+
+
 file = File()
 certs = Certs()
 binary = Binary()
 run = Run()
 docker = Docker()
 phase = Phase()
+config = Config()

--- a/ddb/feature/core/__init__.py
+++ b/ddb/feature/core/__init__.py
@@ -5,7 +5,7 @@ from typing import Iterable, ClassVar
 
 from dotty_dict import Dotty
 
-from .actions import FeaturesAction, ConfigAction
+from .actions import FeaturesAction, ConfigAction, ReloadConfigAction
 from .schema import CoreFeatureSchema
 from ..feature import Feature, FeatureConfigurationAutoConfigureError
 from ..schema import FeatureSchema
@@ -33,7 +33,8 @@ class CoreFeature(Feature):
     def actions(self) -> Iterable[Action]:
         return (
             FeaturesAction(),
-            ConfigAction()
+            ConfigAction(),
+            ReloadConfigAction()
         )
 
     @property

--- a/ddb/feature/core/actions.py
+++ b/ddb/feature/core/actions.py
@@ -1,10 +1,14 @@
 # -*- coding: utf-8 -*-
+import os
+
 import yaml
 
 from .. import features
 from ...action import Action
+from ...action.action import EventBinding
 from ...config import config
 from ...config.flatten import flatten
+from ...context import context
 from ...event import events
 
 
@@ -56,3 +60,49 @@ class ConfigAction(Action):
                 print("%s: %s" % (key, flat[key]))
         else:
             print(yaml.dump(dict(config.data)))
+
+
+class ReloadConfigAction(Action):
+    """
+    In watch mode, reload config if one configuration file is changed.
+    """
+
+    @property
+    def event_bindings(self):
+        def config_file_processor(file: str):
+            if os.path.abspath(file) in config.files:
+                return (), {"file": file}
+            return None
+
+        return (
+            EventBinding(events.file.found, self.execute, config_file_processor)
+        )
+
+    @property
+    def disabled(self) -> bool:
+        return 'watch' not in config.args or not config.args.watch
+
+    @property
+    def name(self) -> str:
+        return "core:reload-config"
+
+    @staticmethod
+    def execute(file: str):
+        """
+        Execute action
+        """
+        if context.watching:
+            data = config.read()
+            if data != config.loaded_data:
+                try:
+                    context.log.info("Configuration file has changed.")
+                    config.clear()
+                    config.load_from_data(data)
+                    all_features = features.all()
+                    for feature in all_features:
+                        feature.configure()
+                    context.log.info("Configuration has been reloaded.")
+                    events.config.reloaded()
+                except Exception as exc:  # pylint:disable=broad-except
+                    context.log.warning("Configuration has fail to reload: %s", str(exc))
+                    return

--- a/ddb/feature/docker/actions.py
+++ b/ddb/feature/docker/actions.py
@@ -199,6 +199,11 @@ class DockerComposeBinaryAction(InitializableAction):
     def initialize(self):
         register_project_cache("docker.binaries")
 
+    def destroy(self):
+        if caches.has("docker.binaries"):
+            cache = caches.unregister("docker.binaries")
+            cache.close()
+
     def before_events(self, docker_compose_config):
         """
         Reset current binaries dict.

--- a/ddb/feature/file/actions.py
+++ b/ddb/feature/file/actions.py
@@ -41,6 +41,11 @@ class FileWalkAction(InitializableAction, WatchSupport):
 
         register_project_cache("file")
 
+    def destroy(self):
+        if caches.has("file"):
+            cache = caches.unregister("file")
+            cache.close()
+
     def execute(self):
         """
         Execute action

--- a/ddb/feature/gitignore/actions.py
+++ b/ddb/feature/gitignore/actions.py
@@ -33,6 +33,11 @@ class UpdateGitignoreAction(InitializableAction):
     def initialize(self):
         register_project_cache("gitignore")
 
+    def destroy(self):
+        if caches.has("gitignore"):
+            cache = caches.unregister("gitignore")
+            cache.close()
+
     @staticmethod
     def find_gitignores(target: str):
         """

--- a/tests/it/test_watch.data/watch-config/ddb.yml
+++ b/tests/it/test_watch.data/watch-config/ddb.yml
@@ -1,0 +1,2 @@
+app:
+  value: "foo"

--- a/tests/it/test_watch.data/watch-config/test.jinja.txt
+++ b/tests/it/test_watch.data/watch-config/test.jinja.txt
@@ -1,0 +1,1 @@
+app.value: {{app.value}}


### PR DESCRIPTION
If a project configuration file changes, configuration is reloaded and command is runned again to update all generated files.

It currently doesn't watch configuration files from ~/.docker-devbox nor ~/.docker-devbox/ddb directories as it's based on file feature events.

Close #67