### PR TITLE
evol(jsonnet): add ServiceName function and implement it in library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ History
 1.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Jsonnet: Add ServiceName function available globally
 
 
 1.2.0 (2020-10-03)

--- a/ddb/feature/jsonnet/lib/ddb.docker.libjsonnet
+++ b/ddb/feature/jsonnet/lib/ddb.docker.libjsonnet
@@ -91,6 +91,7 @@ local apply_disabled_services(compose) =
     else
       compose;
 
+local ServiceName(name=null) = std.join("-", std.prune([_core_project_name, name]));
 
 local Volumes(services) = {
         [key]: {} for key in
@@ -171,14 +172,14 @@ local TraefikRedirectToHttpsLabels(hostname, service_name, redirect_to_https=nul
 local TraefikLabels(port, hostname, name=null, certresolver=null, router_rule=null, redirect_to_https=null) =
 {
     "traefik.enable": "true",
-    ["traefik.http.routers." + std.join("-", std.prune([_core_project_name, name])) + ".service"]: std.join("-", std.prune([_core_project_name, name])),
-    ["traefik.http.routers." + std.join("-", std.prune([_core_project_name, name])) + "-tls.service"]: std.join("-", std.prune([_core_project_name, name])),
-    ["traefik.http.routers." + std.join("-", std.prune([_core_project_name, name])) + "-tls.tls"]: "true",
-    ["traefik.http.services." + std.join("-", std.prune([_core_project_name, name])) + ".loadbalancer.server.port"]: port
+    ["traefik.http.routers." + ServiceName(name) + ".service"]: ServiceName(name),
+    ["traefik.http.routers." + ServiceName(name) + "-tls.service"]: ServiceName(name),
+    ["traefik.http.routers." + ServiceName(name) + "-tls.tls"]: "true",
+    ["traefik.http.services." + ServiceName(name) + ".loadbalancer.server.port"]: port
 }
-+ TraefikCertLabels(hostname, std.join("-", std.prune([_core_project_name, name])), certresolver)
-+ TraefikRoutersRuleLabels(hostname, std.join("-", std.prune([_core_project_name, name])), router_rule)
-+ TraefikRedirectToHttpsLabels(hostname, std.join("-", std.prune([_core_project_name, name])), redirect_to_https);
++ TraefikCertLabels(hostname, ServiceName(name), certresolver)
++ TraefikRoutersRuleLabels(hostname, ServiceName(name), router_rule)
++ TraefikRedirectToHttpsLabels(hostname, ServiceName(name), redirect_to_https);
 
 local TraefikVirtualHost(port, hostname, name=null, network_id=_docker_reverse_proxy_network_id, certresolver=null, router_rule=null, redirect_to_https=null) =
   local vh = {
@@ -216,6 +217,7 @@ local envIs(env) =
     VirtualHost: if _docker_jsonnet_virtualhost_disabled then function(port, hostname, name=null, network_id=_docker_reverse_proxy_network_id, certresolver=null, router_rule=null, redirect_to_https=null){} else VirtualHost,
     TraefikLabels: if _docker_jsonnet_virtualhost_disabled then function(port, hostname, name=null, certresolver=null, router_rule=null, redirect_to_https=null){} else TraefikLabels,
     TraefikCertLabels: if _docker_jsonnet_virtualhost_disabled then function(hostname, service_name, certresolver=null){} else TraefikCertLabels,
+    ServiceName: ServiceName,
     Binary: if _docker_jsonnet_binary_disabled then function(name, workdir = null, args = null, options = null, options_condition = null, exe = null){} else Binary,
     BinaryLabels: if _docker_jsonnet_binary_disabled then function(name, workdir = null, args = null, options = null, options_condition = null, exe = null){} else BinaryLabels,
     BinaryOptions: if _docker_jsonnet_binary_disabled then function(name, options, condition = null, index = null){} else BinaryOptions,

--- a/docs/features/jsonnet.md
+++ b/docs/features/jsonnet.md
@@ -154,6 +154,30 @@ The `restart` configuration will be set with the `docker.restart_policy` ddb con
     image: nginx:latest
     ```
 
+### ServiceName
+This function generates the right service name for a service.
+
+The main purpose is to have more easy way to manage Labels for traefik and easily add a middleware to a specific 
+service.
+
+It concatenates the given name with the name of the project.
+
+!!! abstract "Parameters"
+    - `name`: 
+    The name of the service
+        - type: string
+
+
+!!! example
+    With a project named "ddb" 
+    ```json 
+    ddb.ServiceName("test")
+    ```
+    will return
+    ```yaml
+    ddb-test
+    ```
+
 ### User
 This function generates the `user` configuration for a service.
 

--- a/tests/feature/jsonnet/test_jsonnet.data/docker_compose_variables/docker-compose.expected.yml
+++ b/tests/feature/jsonnet/test_jsonnet.data/docker_compose_variables/docker-compose.expected.yml
@@ -83,6 +83,8 @@ services:
     image: gfiorleans.azurecr.io/gli-biometrie/web
     init: true
     labels:
+      traefik.http.middlewares.biometrie-auth.basicauth.users: "biometrie:$$apr1$$oTBtKtGR$$JlgPB1ZdGh1bYfPonp0IB0"
+      traefik.http.routers.gli-biometrie-api-tls.middlewares: "biometrie-auth"
       traefik.enable: "true"
       traefik.http.routers.gli-biometrie-api-tls.rule: Host(`api.biometrie.test`)
       traefik.http.routers.gli-biometrie-api-tls.service: gli-biometrie-api

--- a/tests/feature/jsonnet/test_jsonnet.data/docker_compose_variables/docker-compose.yml.jsonnet
+++ b/tests/feature/jsonnet/test_jsonnet.data/docker_compose_variables/docker-compose.yml.jsonnet
@@ -62,7 +62,11 @@ local services = {
 }
 
 + {
-    "web": ddb.Build("web") + ddb.VirtualHost("80", "api.biometrie.test", "api", certresolver=certresolver, router_rule=router_rule) {
+    "web": ddb.Build("web") + ddb.VirtualHost("80", "api.biometrie.test", "api", certresolver=certresolver, router_rule=router_rule) + {
+        "labels"+: {
+            "traefik.http.middlewares.biometrie-auth.basicauth.users":"biometrie:$$apr1$$oTBtKtGR$$JlgPB1ZdGh1bYfPonp0IB0",
+            ["traefik.http.routers." + ddb.ServiceName("api") + "-tls.middlewares"]:"biometrie-auth"
+        },
         "volumes": [
             ddb.path.project + "/.docker/web/nginx.conf:/etc/nginx/conf.d/default.conf:rw",
             ddb.path.project + ":/var/www/html:rw"


### PR DESCRIPTION
In order to help with addition of traefik label into docker-compose.yml.jsonnet, I have added a simple function to jsonnet library : ServiceName. 

His purpose is to simply add a way to generate the service name used in TraefikLabel inside our custom library and to be used directly in project files.

It is in relation with #91 evolution.