### PR TITLE
feat(binaries): allow many binaries to be registered for the same name

### DIFF
--- a/ddb/__main__.py
+++ b/ddb/__main__.py
@@ -344,6 +344,7 @@ def main(args: Optional[Sequence[str]] = None,
     global _watch_started_event, _watch_stop_event  # pylint:disable=global-statement
     _watch_started_event = threading.Event()
     _watch_stop_event = threading.Event()
+    initial_cwd = os.getcwd()
     try:
         load_plugins()
         bootstrap_register_features()
@@ -397,6 +398,7 @@ def main(args: Optional[Sequence[str]] = None,
     except ExpectedError as exception:
         return [exception]
     finally:
+        os.chdir(initial_cwd)
         if not reset_disabled:
             reset()
 

--- a/ddb/binary/__init__.py
+++ b/ddb/binary/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
 from .binary import Binary
-from ..registry import Registry
+from ..registry import RegistryOrderedSet
 
-binaries = Registry(Binary, "Binary")  # type: Registry[Binary]
+binaries = RegistryOrderedSet(Binary, "Binary")  # type: RegistryOrderedSet[Binary]

--- a/ddb/binary/binary.py
+++ b/ddb/binary/binary.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from abc import abstractmethod, ABC
-from typing import List, Iterable
+from typing import Iterable, Tuple
 
 from ddb.registry import RegistryObject
 
@@ -10,17 +10,35 @@ class Binary(RegistryObject, ABC):
     Wraps a binary on the system.
     """
 
+    @property
     @abstractmethod
-    def command(self, *args) -> Iterable[str]:
+    def name(self) -> str:
         """
-        Get the binary command
+        Name of the binary.
         """
 
     @abstractmethod
-    def pre_execute(self):
+    def command(self, *args) -> Iterable[str]:
         """
-        Add action to be executed before running the command
-        :return: True or False depending on it's the same or not
+        Get the binary command.
+        """
+
+    @abstractmethod
+    def should_run(self, *args) -> bool:
+        """
+        Check if this binary should run.
+        """
+
+    @abstractmethod
+    def priority(self) -> int:
+        """
+        Priority of this binary amoung binaries with the same name that should run.
+        """
+
+    @abstractmethod
+    def before_run(self, *args) -> None:
+        """
+        Add action to be executed before running the command.
         """
 
     @abstractmethod
@@ -44,6 +62,15 @@ class AbstractBinary(Binary, ABC):
     def name(self) -> str:
         return self._name
 
+    def before_run(self, *args) -> None:
+        return None
+
+    def should_run(self, *args) -> bool:
+        return True
+
+    def priority(self) -> int:
+        return 0
+
     def __eq__(self, other) -> bool:
         if not isinstance(other, AbstractBinary):
             return False
@@ -58,11 +85,11 @@ class DefaultBinary(AbstractBinary):
     Default implementation for binary.
     """
 
-    def __init__(self, name: str, command: List[str]):
+    def __init__(self, name: str, command: Iterable[str]):
         super().__init__(name)
-        self._command = command
+        self._command = tuple(command)
 
-    def command(self, *args) -> List[str]:
+    def command(self, *args) -> Tuple[str]:
         return self._command
 
     def __eq__(self, other) -> bool:
@@ -74,6 +101,3 @@ class DefaultBinary(AbstractBinary):
 
     def __hash__(self):
         return hash((super().__hash__(), self.command()))
-
-    def pre_execute(self):
-        return True

--- a/ddb/cache/removal.py
+++ b/ddb/cache/removal.py
@@ -57,5 +57,4 @@ class RemovalCacheSupport:  # pylint:disable=too-many-instance-attributes
         """
         Unregister and close the underlying cache.
         """
-        cache = caches.unregister("traefik.extra-services")
-        cache.close()
+        caches.unregister("traefik.extra-services", callback=lambda c: c.close())

--- a/ddb/config/config.py
+++ b/ddb/config/config.py
@@ -91,6 +91,16 @@ class Config:  # pylint:disable=too-many-instance-attributes
         self.env_additions.clear()
 
     @property
+    def project_cwd(self):
+        """
+        Retrieve the current working directory, relative to project_home.
+        :return:
+        """
+        if self.paths.project_home and self.cwd:
+            return os.path.relpath(self.cwd, self.paths.project_home)
+        return None
+
+    @property
     def eject(self):
         """
         Check if command line is running configure command with --eject flag.

--- a/ddb/event/events.py
+++ b/ddb/event/events.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Optional, Union, Iterable
 
 from ddb.binary import Binary as BinaryType
 from . import event
@@ -124,6 +124,14 @@ class Run:
         :param name:
         """
 
+    @event("run:command")
+    def command(self, command: Iterable[str], system_path: bool = False):
+        """
+        When a command request should be handled.
+        :param command:
+        :param system_path:
+        """
+
 
 class Docker:
     """
@@ -152,17 +160,10 @@ class Docker:
         """
 
     @event("docker:binary")
-    def binary(self, name=None, workdir=None, options=None, options_condition=None, args=None,
+    def binary(self, name=None, workdir=None, options=None, options_condition=None, condition=None, args=None,
                docker_compose_service=None):
         """
         Ask a binary to be generated from docker compose service
-        :param name:
-        :param workdir:
-        :param options:
-        :param options_condition:
-        :param args:
-        :param docker_compose_service:
-        :return:
         """
 
 

--- a/ddb/feature/file/actions.py
+++ b/ddb/feature/file/actions.py
@@ -43,8 +43,7 @@ class FileWalkAction(InitializableAction, WatchSupport):
 
     def destroy(self):
         if caches.has("file"):
-            cache = caches.unregister("file")
-            cache.close()
+            caches.unregister("file", callback=lambda c: c.close())
 
     def execute(self):
         """

--- a/ddb/feature/gitignore/actions.py
+++ b/ddb/feature/gitignore/actions.py
@@ -35,8 +35,7 @@ class UpdateGitignoreAction(InitializableAction):
 
     def destroy(self):
         if caches.has("gitignore"):
-            cache = caches.unregister("gitignore")
-            cache.close()
+            caches.unregister("gitignore", callback=lambda c: c.close())
 
     @staticmethod
     def find_gitignores(target: str):

--- a/ddb/feature/jsonnet/lib/ddb.docker.libjsonnet
+++ b/ddb/feature/jsonnet/lib/ddb.docker.libjsonnet
@@ -32,7 +32,6 @@ local _core_env_available = std.extVar("core.env.available");
 local _core_path_project_home = std.extVar("core.path.project_home");
 local _core_path_ddb_home = std.extVar("core.path.ddb_home");
 local _core_path_home = std.extVar("core.path.home");
-local _eject = std.extVar("_config.eject");
 
 # local sep = if _core_os == "nt" then std.char(92) else "/"; # Backslash can't be escaped properly, so use std.char
 
@@ -146,26 +145,31 @@ local Volumes(services) = {
         )
 };
 
+local NoBinaryOptionsLabels(name, options, options_condition = null, index = null) = {};
 local BinaryOptionsLabels(name, options, options_condition = null, index = null) = {
-    ["ddb.emit.docker:binary[" + name + "](options)" + (if index != null then "(c" + index + ")" else "")]: options,
+    ["ddb.emit.docker:binary[" + name + "](options)" + (if index != null then "(c" + index + ")" else "")]: options_condition,
     [if options_condition != null then "ddb.emit.docker:binary[" + name + "](options_condition)" + (if index != null then "(c" + index + ")" else "")]: options_condition
 };
 
-local BinaryOptions(name, options, condition = null, index = null) = {
-    labels +: BinaryOptionsLabels(name, options, condition, index),
+local NoBinaryOptions(name, options, options_condition = null, index = null) = {};
+local BinaryOptions(name, options, options_condition = null, index = null) = {
+    labels +: BinaryOptionsLabels(name, options, options_condition, index),
 };
 
-local BinaryLabels(name, workdir = null, args = null, options = null, options_condition = null, exe = null) = {
+local NoBinaryLabels(name, workdir = null, args = null, options = null, options_condition = null, exe = null, condition = null) = {};
+local BinaryLabels(name, workdir = null, args = null, options = null, options_condition = null, exe = null, condition = null) = {
     ["ddb.emit.docker:binary[" + name + "](name)"]: name,
     [if workdir != null then "ddb.emit.docker:binary[" + name + "](workdir)"]: workdir,
     [if args != null then "ddb.emit.docker:binary[" + name + "](args)"]: args,
     [if options != null then "ddb.emit.docker:binary[" + name + "](options)"]: options,
     [if options_condition != null then "ddb.emit.docker:binary[" + name + "](options_condition)"]: options_condition,
-    [if exe != null then "ddb.emit.docker:binary[" + name + "](exe)"]: exe
+    [if exe != null then "ddb.emit.docker:binary[" + name + "](exe)"]: exe,
+    [if condition != null then "ddb.emit.docker:binary[" + name + "](condition)"]: condition
 };
 
-local Binary(name, workdir = null, args = null, options = null, options_condition = null, exe = null) = {
-    labels +: BinaryLabels(name, workdir, args, options, options_condition, exe),
+local NoBinary(name, workdir = null, args = null, options = null, options_condition = null, exe = null, condition=null) = {};
+local Binary(name, workdir = null, args = null, options = null, options_condition = null, exe = null, condition=null) = {
+    labels +: BinaryLabels(name, workdir, args, options, options_condition, exe, condition),
 };
 
 local Networks(services, network_names=_docker_reverse_proxy_network_names) = {
@@ -190,6 +194,7 @@ local Compose(config={}, network_names=_docker_reverse_proxy_network_names, vers
         "volumes": Volumes(self.services)
     };
 
+local NoTraefikCertLabels(hostname, service_name, certresolver=null) = {};
 local TraefikCertLabels(hostname, service_name, certresolver=null) = {
     [if certresolver != null then "traefik.http.routers." + service_name + "-tls.tls.certresolver"]: certresolver,
     [if (certresolver == null && _docker_reverse_proxy_certresolver != null) then "traefik.http.routers." + service_name + "-tls.tls.certresolver"]: _docker_reverse_proxy_certresolver,
@@ -237,6 +242,7 @@ local TraefikRedirectToHttpsLabels(hostname, service_name, redirect_to_https=nul
       [if effective_redirect_to_https == true then "traefik.http.middlewares." + service_name + "-redirect-to-https.redirectscheme.scheme"]: "https",
     };
 
+local NoTraefikLabels(port, hostname, name=null, certresolver=null, router_rule=null, redirect_to_https=null, https=null, path_prefix=null, redirect_to_path_prefix=null) = {};
 local TraefikLabels(port, hostname, name=null, certresolver=null, router_rule=null, redirect_to_https=null, https=null, path_prefix=null, redirect_to_path_prefix=null) =
 local effective_https = if https != null then https else _docker_reverse_proxy_https;
 {
@@ -269,11 +275,12 @@ local VirtualHost = if _docker_reverse_proxy_type == "traefik" then TraefikVirtu
 
 // XDebug 3 configuration has changed.
 // Default TCP port has changed from 9000 to 9003, but we still configure it to 9000 to avoid confusion while configuring code editors.
+local NoXDebug(version=null, session=_core_project_name, mode="debug") = {};
 local XDebug(version=null, session=_core_project_name, mode="debug") =
 local xdebug2_config = ["remote_enable=" + if mode != "off" then "on" else "off", "remote_autostart=off", "idekey=" + session, "remote_host=" + _docker_debug_host];
 local xdebug3_config = ["client_host=" + _docker_debug_host, "client_port=9000"];
 {
-    [if !_docker_debug_disabled then "environment"]: {
+    environment: {
         [if version == null || version == 2 then "PHP_IDE_CONFIG"]: "serverName=" + session,
         [if version == null || version == 3 then "XDEBUG_MODE"]: mode,
         [if version == null || version == 3 then "XDEBUG_SESSION"]: session,
@@ -295,14 +302,14 @@ local envIs(env) =
     Image: Image,
     Build: Build,
     VirtualHost: if _docker_jsonnet_virtualhost_disabled then NoVirtualHost else VirtualHost,
-    TraefikLabels: if _docker_jsonnet_virtualhost_disabled then function(port, hostname, name=null, certresolver=null, router_rule=null, redirect_to_https=null){} else TraefikLabels,
-    TraefikCertLabels: if _docker_jsonnet_virtualhost_disabled then function(hostname, service_name, certresolver=null){} else TraefikCertLabels,
+    TraefikLabels: if _docker_jsonnet_virtualhost_disabled then NoTraefikLabels else TraefikLabels,
+    TraefikCertLabels: if _docker_jsonnet_virtualhost_disabled then NoTraefikCertLabels else TraefikCertLabels,
     ServiceName: ServiceName,
-    Binary: if _docker_jsonnet_binary_disabled then function(name, workdir = null, args = null, options = null, options_condition = null, exe = null){} else Binary,
-    BinaryLabels: if _docker_jsonnet_binary_disabled then function(name, workdir = null, args = null, options = null, options_condition = null, exe = null){} else BinaryLabels,
-    BinaryOptions: if _docker_jsonnet_binary_disabled then function(name, options, condition = null, index = null){} else BinaryOptions,
-    BinaryOptionsLabels: if _docker_jsonnet_binary_disabled then function(name, options, options_condition = null, index = null){} else BinaryOptionsLabels,
-    XDebug: XDebug,
+    Binary: if _docker_jsonnet_binary_disabled then NoBinary else Binary,
+    BinaryLabels: if _docker_jsonnet_binary_disabled then NoBinaryLabels else BinaryLabels,
+    BinaryOptions: if _docker_jsonnet_binary_disabled then NoBinaryOptions else BinaryOptions,
+    BinaryOptionsLabels: if _docker_jsonnet_binary_disabled then NoBinaryOptionsLabels else BinaryOptionsLabels,
+    XDebug: if _docker_debug_disabled then NoXDebug else XDebug,
     Compose: Compose,
     Volumes: Volumes,
     Expose: Expose,

--- a/ddb/feature/run/actions.py
+++ b/ddb/feature/run/actions.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
-import subprocess
+from typing import Optional, Iterable
 
-from ...context import context
 from ...action import Action
 from ...action.action import EventBinding
-from ...binary import binaries
+from ...binary import binaries, Binary
 from ...config import config
 from ...event import events
 
@@ -42,8 +41,24 @@ class RunAction(Action):
         if not args:
             args = config.unknown_args
 
-        binary = binaries.get(name)
-        if binary.pre_execute():
-            print(subprocess.list2cmdline(binary.command(*args)))
+        binary_set = binaries.get(name)
+        binary = None
+        if binary_set:
+            binary = RunAction.select_binary(binary_set, *args)
+
+        if binary:
+            binary.before_run()
+            events.run.command(binary.command(*args), False)
         else:
-            context.log.error("An error occurred in pre-execution controls of the binary")
+            events.run.command([name, *args], True)
+
+    @staticmethod
+    def select_binary(binary_set: Iterable[Binary], *args) -> Optional[Binary]:
+        """
+        Select effective binary between many binaries.
+        """
+        ordered_binary = sorted(binary_set)
+        for binary in ordered_binary:
+            if binary.should_run(*args):
+                return binary
+        return None

--- a/ddb/feature/shell/__init__.py
+++ b/ddb/feature/shell/__init__.py
@@ -4,7 +4,8 @@ from typing import Iterable, ClassVar
 
 from dotty_dict import Dotty
 
-from .actions import ActivateAction, DeactivateAction, CreateBinaryShim, CreateAliasShim, CheckActivatedAction
+from .actions import ActivateAction, DeactivateAction, CreateBinaryShim, CreateAliasShim, CheckActivatedAction, \
+    CommandAction
 from .integrations import BashShellIntegration, CmdShellIntegration
 from .schema import ShellSchema
 from ..feature import Feature, FeatureConfigurationAutoConfigureError
@@ -39,11 +40,13 @@ class ShellFeature(Feature):
             CreateBinaryShim(BashShellIntegration()),
             CreateAliasShim(BashShellIntegration()),
             CheckActivatedAction(BashShellIntegration()),
+            CommandAction(BashShellIntegration()),
             ActivateAction(CmdShellIntegration()),
             DeactivateAction(CmdShellIntegration()),
             CreateBinaryShim(CmdShellIntegration()),
             CreateAliasShim(CmdShellIntegration()),
-            CheckActivatedAction(CmdShellIntegration())
+            CheckActivatedAction(CmdShellIntegration()),
+            CommandAction(CmdShellIntegration())
         )
 
     @property

--- a/ddb/registry.py
+++ b/ddb/registry.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 import inspect
 from abc import abstractmethod, ABC
-from typing import TypeVar, Generic, Iterable, ClassVar, TYPE_CHECKING
+from collections import defaultdict
+from typing import TypeVar, Generic, ClassVar, TYPE_CHECKING, Tuple, Optional, Callable, Any
+
+from ordered_set import OrderedSet
 
 if TYPE_CHECKING:
     from ddb.cache import Cache  # pylint:disable=cyclic-import
@@ -67,7 +70,10 @@ class Registry(Generic[T]):
         self._cache = cache
         if self._cache:
             for key in self._cache.keys():
-                self.register(self._cache.get(key), key)
+                self._register_cache_value_impl(self._cache.get(key), key)
+
+    def _register_cache_value_impl(self, value, key):
+        self.register(value, key)
 
     def _default_name(self, obj: T):  # pylint:disable=no-self-use
         """
@@ -88,36 +94,57 @@ class Registry(Generic[T]):
                              name + "\" should be an instance of " +
                              self._clazz.__name__)
 
+        data = self._register_impl(name, obj)
+        return data
+
+    def _register_impl(self, name: str, obj: T):
         if name in self._objects_dict:
             raise ValueError(self._type_name + " name \"" + name + "\" is already registered")
 
         self._objects_dict[name] = obj
         self._objects.append(obj)
 
-        if self._cache and (name not in self._cache or self._cache.get(name) != obj):
+        if self._cache and obj and (name not in self._cache or self._cache.get(name) != obj):
             self._cache.set(name, obj)
             self._cache.flush()
 
-        return name
+        return obj
 
-    def has(self, name: str) -> bool:
+    def has(self, name: str, obj: Optional[T] = None) -> bool:
         """
         Check if name is registered.
         """
-        return name in self._objects_dict
+        ret = name in self._objects_dict
+        if ret and obj is not None:
+            return self._has_obj_impl(self._objects_dict.get(name), obj)
+        return ret
 
-    def unregister(self, name):
+    def _has_obj_impl(self, dict_value, obj) -> bool:  # pylint:disable=no-self-use
+        return dict_value == obj
+
+    def unregister(self, name, obj: Optional[T] = None, callback: Optional[Callable[[T], Any]] = None) -> bool:
         """
         Unregister an object instance
         """
         if name not in self._objects_dict:
             raise ValueError(self._type_name + " name \"" + name + "\" is not registered")
 
-        item = self._objects_dict.pop(name)
-        self._objects.remove(item)
-        if self._cache and name in self._cache:
-            self._cache.pop(name)
-        return item
+        return self._unregister_impl(name, obj, callback)
+
+    def _unregister_impl(self, name, obj=None, callback: Optional[Callable[[T], Any]] = None) -> bool:
+        item = self._objects_dict.get(name)
+        if obj is None or item == obj:
+            self._objects_dict.pop(name)
+            self._objects.remove(item)
+
+            if self._cache and name in self._cache:
+                self._cache.pop(name)
+
+            if callback:
+                callback(item)
+
+            return True
+        return False
 
     def get(self, name: str) -> T:
         """
@@ -127,7 +154,7 @@ class Registry(Generic[T]):
             raise ValueError(self._type_name + " name \"" + name + "\" is not registered")
         return self._objects_dict[name]
 
-    def all(self) -> Iterable[T]:
+    def all(self) -> Tuple[T]:
         """
         Get all object instances.
         """
@@ -151,3 +178,56 @@ class Registry(Generic[T]):
             self._cache.close()
             self._cache = None
         self.clear()
+
+
+class RegistryOrderedSet(Registry):
+    """
+    Container for registered objects. Objects set can be retrieved with their unique name.
+    """
+    def __init__(self, clazz: ClassVar[T], type_name="Object"):
+        super().__init__(clazz, type_name)
+        self._objects_dict = defaultdict(OrderedSet)
+
+    def _register_cache_value_impl(self, value, key):
+        for obj in value:
+            self.register(obj, key)
+
+    def _register_impl(self, name: str, obj: T):
+        items = self._objects_dict[name]
+        if obj in items:
+            raise ValueError("This " + self._type_name + " is already registered for name \"" + name + "\"")
+        items.add(obj)
+        self._objects.append(obj)
+
+        if self._cache:
+            self._cache.set(name, items)
+            self._cache.flush()
+
+        return items
+
+    def _unregister_impl(self, name, obj=None, callback: Optional[Callable[[T], Any]] = None) -> bool:
+        items = self._objects_dict.get(name)
+        ret = False
+        if items:
+            for item in items:
+                if not obj or obj == item:
+                    items.remove(item)
+                    self._objects.remove(item)
+                    ret = True
+                    if callback:
+                        callback(item)
+            if ret:
+                if not items:
+                    self._objects_dict.pop(name)
+                    if self._cache and name in self._cache:
+                        self._cache.pop(name)
+                else:
+                    if self._cache:
+                        self._cache.set(name, items)
+        return ret
+
+    def _has_obj_impl(self, dict_value: OrderedSet[T], obj) -> bool:
+        return obj in dict_value
+
+    def get(self, name: str) -> OrderedSet[T]:  # pylint:disable=useless-super-delegation
+        return super().get(name)

--- a/docs/features/jsonnet.md
+++ b/docs/features/jsonnet.md
@@ -366,6 +366,8 @@ Binary allow the creation of alias for command execution inside the service.
         - type: string|null
     - `exe`: launch command with docker-compose `exec` instead of `run`.
         - type: boolean|null
+    - `condition`: add a condition for the command to be enabled or not.
+        - type: string|null
 
 !!! example 
     ```json 

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ paramiko
 wcmatch
 marshmallow-union
 progress
+ordered-set

--- a/tests/feature/docker/test_docker.data/binary-condition/docker-compose.yml
+++ b/tests/feature/docker/test_docker.data/binary-condition/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.7'
+services:
+  node:
+    image: node:10
+    init: true
+    labels:
+      ddb.emit.docker:binary[npm](name): npm-simple
+      ddb.emit.docker:binary[npm](workdir): /app
+    restart: 'no'
+    user: 1000:1000
+    volumes:
+      - .:/app
+      - node-cache:/home/node/.cache
+  node2:
+    image: node:12
+    init: true
+    labels:
+      ddb.emit.docker:binary[mysql](name): mysql
+      ddb.emit.docker:binary[mysql](args): mysql -hdb -uproject-management-tool -pproject-management-tool
+      ddb.emit.docker:binary[mysql](workdir): /app
+    restart: 'no'
+    user: 1000:1000
+    volumes:
+      - .:/app
+      - db-data:/var/lib/mysql
+volumes:
+  node-cache:
+  db-data:

--- a/tests/it/test_binaries.data/docker_command_cwd_condition/docker-compose.yml
+++ b/tests/it/test_binaries.data/docker_command_cwd_condition/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3.7"
+services:
+  node14:
+    image: node:14-alpine
+    labels:
+      ddb.emit.docker:binary[node](name): node
+  node12:
+    image: node:12-alpine
+    labels:
+      ddb.emit.docker:binary[node](name): node
+      ddb.emit.docker:binary[node](condition): "'/node12' in cwd"
+  node10:
+    image: node:10-alpine
+    labels:
+      ddb.emit.docker:binary[node](name): node
+      ddb.emit.docker:binary[node](condition): "'/node10' in cwd"

--- a/tests/it/test_eject_it.py
+++ b/tests/it/test_eject_it.py
@@ -1,6 +1,7 @@
 import os
 
 import yaml
+
 from ddb.__main__ import main
 from tests.utilstest import expect_gitignore, setup_cfssl
 

--- a/tests/it/test_jsonnet_it.data/jsonnet-binary/docker-compose.expected.yml
+++ b/tests/it/test_jsonnet_it.data/jsonnet-binary/docker-compose.expected.yml
@@ -1,0 +1,39 @@
+networks: {}
+services:
+  node10:
+    image: node:10
+    init: true
+    labels:
+      ddb.emit.docker:binary[node](name): node
+      ddb.emit.docker:binary[node](options): --version
+      ddb.emit.docker:binary[node](options_condition): 'True'
+      ddb.emit.docker:binary[node](workdir): /app
+      ddb.emit.docker:binary[npm](name): npm
+      ddb.emit.docker:binary[npm](options): --version
+      ddb.emit.docker:binary[npm](options_condition): 'False'
+      ddb.emit.docker:binary[npm](workdir): /app
+    restart: 'no'
+  node12:
+    image: node:12
+    init: true
+    labels:
+      ddb.emit.docker:binary[node](condition): "'12' in cwd"
+      ddb.emit.docker:binary[node](name): node
+      ddb.emit.docker:binary[node](workdir): /workdir
+      ddb.emit.docker:binary[npm](condition): "'12' in cwd"
+      ddb.emit.docker:binary[npm](name): npm
+      ddb.emit.docker:binary[npm](workdir): /workdir
+    restart: 'no'
+  node14:
+    image: node:14
+    init: true
+    labels:
+      ddb.emit.docker:binary[node](exe): true
+      ddb.emit.docker:binary[node](name): node
+      ddb.emit.docker:binary[node](workdir): /
+      ddb.emit.docker:binary[npm](exe): false
+      ddb.emit.docker:binary[npm](name): npm
+      ddb.emit.docker:binary[npm](workdir): /
+    restart: 'no'
+version: '3.7'
+volumes: {}

--- a/tests/it/test_jsonnet_it.data/jsonnet-binary/docker-compose.yml.jsonnet
+++ b/tests/it/test_jsonnet_it.data/jsonnet-binary/docker-compose.yml.jsonnet
@@ -1,0 +1,16 @@
+local ddb = import 'ddb.docker.libjsonnet';
+
+ddb.Compose({
+	services: {
+        node10: ddb.Image("node:10") +
+                ddb.Binary("node", "/app", options="--version", options_condition='True') +
+                ddb.Binary("npm", "/app", options="--version", options_condition='False'),
+        node12: ddb.Image("node:12") +
+                ddb.Binary("node", "/workdir", condition="'12' in cwd") +
+                ddb.Binary("npm", "/workdir", condition="'12' in cwd"),
+        node14: ddb.Image("node:14") +
+                ddb.Binary("node", "/", exe=true) +
+                ddb.Binary("npm", "/", exe=false),
+         }
+    })
+

--- a/tests/it/test_jsonnet_it.py
+++ b/tests/it/test_jsonnet_it.py
@@ -42,3 +42,17 @@ class TestDockerJsonnet:
 
         with pytest.raises(RuntimeError):
             main(["configure"])
+
+    def test_binary(self, project_loader):
+        project_loader("jsonnet-binary")
+
+        main(["configure"])
+
+        assert os.path.exists('docker-compose.yml')
+        with open('docker-compose.yml', 'r') as f:
+            docker_compose = yaml.load(f, yaml.SafeLoader)
+
+        with open('docker-compose.expected.yml', 'r') as f:
+            docker_compose_expected = yaml.load(f, yaml.SafeLoader)
+
+        assert docker_compose == docker_compose_expected

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from ddb.registry import Registry, DefaultRegistryObject
+from ddb.binary.binary import DefaultBinary, Binary
+from ddb.feature.docker.binaries import DockerBinary
+from ddb.registry import Registry, DefaultRegistryObject, RegistryOrderedSet
 
 
 class Dummy(DefaultRegistryObject):
@@ -12,80 +14,217 @@ class Another(DefaultRegistryObject):
     pass
 
 
+class HashbableDummy(DefaultRegistryObject):
+    def __init__(self, name, a, b):
+        super().__init__(name)
+        self.a = a
+        self.b = b
+
+    def __eq__(self, other):
+        if not isinstance(other, HashbableDummy):
+            return False
+        return self.a == other.a and self.b == other.b
+
+    def __hash__(self):
+        return hash(self.a) ^ hash(self.b)
+
+
 class NoName:
     pass
 
 
-def test_empty():
-    r = Registry(Dummy, "Dummy")
+class TestRegistry:
+    def test_empty(self):
+        r = Registry(Dummy, "Dummy")
 
-    assert len(r.all()) == 0
+        assert r.all() == ()
 
+    def test_register(self):
+        r = Registry(Dummy, "Dummy")
 
-def test_register():
-    r = Registry(Dummy, "Dummy")
-
-    d = Dummy("dummy")
-    r.register(d)
-
-    assert r.get("dummy") == d
-
-
-def test_register_alternative_name():
-    r = Registry(Dummy, "Dummy")
-
-    d = Dummy("dummy")
-    r.register(d, "alt")
-
-    with pytest.raises(ValueError) as e:
-        r.get("dummy")
-    assert str(e.value) == "Dummy name \"dummy\" is not registered"
-
-    assert r.get("alt") == d
-
-
-def test_cant_register_many_times():
-    r = Registry(Dummy, "Dummy")
-
-    d = Dummy("dummy")
-    r.register(d)
-
-    with pytest.raises(ValueError) as e:
+        d = Dummy("dummy")
         r.register(d)
-    assert str(e.value) == "Dummy name \"dummy\" is already registered"
+
+        assert r.get("dummy") == d
+        assert r.all() == (d,)
+
+    def test_register_and_unregister(self):
+        r = Registry(Dummy, "Dummy")
+
+        d = Dummy("dummy")
+        r.register(d)
+
+        assert r.get("dummy") == d
+        assert r.all() == (d,)
+
+        r.unregister("dummy")
+        with pytest.raises(ValueError) as e:
+            r.get("dummy")
+        assert str(e.value) == "Dummy name \"dummy\" is not registered"
+        assert not r.has("dummy")
+        assert r.all() == ()
+
+    def test_register_alternative_name(self):
+        r = Registry(Dummy, "Dummy")
+
+        d = Dummy("dummy")
+        r.register(d, "alt")
+
+        with pytest.raises(ValueError) as e:
+            r.get("dummy")
+        assert str(e.value) == "Dummy name \"dummy\" is not registered"
+
+        assert r.get("alt") == d
+        assert r.all() == (d,)
+
+    def test_cant_register_many_times(self):
+        r = Registry(Dummy, "Dummy")
+
+        d = Dummy("dummy")
+        r.register(d)
+
+        with pytest.raises(ValueError) as e:
+            r.register(d)
+        assert str(e.value) == "Dummy name \"dummy\" is already registered"
+
+    def test_unregistered(self):
+        r = Registry(Dummy, "Dummy")
+
+        with pytest.raises(ValueError) as e:
+            r.get("dummy")
+        assert str(e.value) == "Dummy name \"dummy\" is not registered"
+
+    def test_register_another_class(self):
+        r = Registry(Dummy, "Dummy")
+
+        with pytest.raises(ValueError) as e:
+            r.register(Another("testing"))
+        assert str(e.value) == "Dummy name \"testing\" should be an instance of Dummy"
+
+    def test_register_invalid_instance(self):
+        r = Registry(Dummy, "Dummy")
+
+        n = NoName()
+
+        with pytest.raises(ValueError) as e:
+            r.register(n, "no-name")
+        assert str(e.value) == "Dummy name \"no-name\" should be an instance of Dummy"
+
+    def test_register_no_name_class_missing_name(self):
+        r = Registry(NoName, "NoName")
+
+        n = NoName()
+
+        with pytest.raises(ValueError) as e:
+            r.register(n)
+        assert str(e.value) == "Name should be provided to register this kind of object"
 
 
-def test_unregistered():
-    r = Registry(Dummy, "Dummy")
+class TestRegistrySet:
+    def test_empty(self):
+        r = RegistryOrderedSet(HashbableDummy, "HashbableDummy")
 
-    with pytest.raises(ValueError) as e:
-        r.get("dummy")
-    assert str(e.value) == "Dummy name \"dummy\" is not registered"
+        assert len(r.all()) == 0
 
+    def test_register(self):
+        r = RegistryOrderedSet(HashbableDummy, "HashbableDummy")
 
-def test_register_another_class():
-    r = Registry(Dummy, "Dummy")
+        d = HashbableDummy("dummy", "1", "2")
+        r.register(d)
 
-    with pytest.raises(ValueError) as e:
-        r.register(Another("testing"))
-    assert str(e.value) == "Dummy name \"testing\" should be an instance of Dummy"
+        assert r.get("dummy") == [d]
 
+    def test_register_and_unregister(self):
+        r = RegistryOrderedSet(HashbableDummy, "HashbableDummy")
 
-def test_register_invalid_instance():
-    r = Registry(Dummy, "Dummy")
+        d = HashbableDummy("dummy", "1", "2")
+        r.register(d)
 
-    n = NoName()
+        assert r.get("dummy") == {d}
+        assert r.all() == (d,)
 
-    with pytest.raises(ValueError) as e:
-        r.register(n, "no-name")
-    assert str(e.value) == "Dummy name \"no-name\" should be an instance of Dummy"
+        r.unregister("dummy")
+        with pytest.raises(ValueError) as e:
+            r.get("dummy")
+        assert str(e.value) == "HashbableDummy name \"dummy\" is not registered"
+        assert not r.has("dummy")
+        assert r.all() == ()
 
+    def test_register_alternative_name(self):
+        r = RegistryOrderedSet(HashbableDummy, "HashbableDummy")
 
-def test_register_no_name_class_missing_name():
-    r = Registry(NoName, "NoName")
+        d = HashbableDummy("dummy", "1", "2")
+        r.register(d, "alt")
 
-    n = NoName()
+        with pytest.raises(ValueError) as e:
+            r.get("dummy")
+        assert str(e.value) == "HashbableDummy name \"dummy\" is not registered"
 
-    with pytest.raises(ValueError) as e:
-        r.register(n)
-    assert str(e.value) == "Name should be provided to register this kind of object"
+        assert r.get("alt") == {d}
+
+    def test_skip_allready_registered_same_instance(self):
+        r = RegistryOrderedSet(HashbableDummy, "HashbableDummy")
+
+        d = HashbableDummy("dummy", "1", "2")
+        r.register(d)
+
+        d2 = HashbableDummy("dummy", "1", "2")
+        with pytest.raises(ValueError) as e:
+            r.register(d2)
+        assert str(e.value) == "This HashbableDummy is already registered for name \"dummy\""
+
+        d3 = HashbableDummy("dummy", "1", "3")
+        r.register(d3)
+
+        assert r.get("dummy") == {d, d3}
+        assert r.all() == (d, d3)
+
+    def test_unregistered(self):
+        r = RegistryOrderedSet(HashbableDummy, "HashbableDummy")
+
+        with pytest.raises(ValueError) as e:
+            r.get("dummy")
+        assert str(e.value) == "HashbableDummy name \"dummy\" is not registered"
+
+    def test_register_another_class(self):
+        r = RegistryOrderedSet(HashbableDummy, "HashbableDummy")
+
+        with pytest.raises(ValueError) as e:
+            r.register(Another("testing"))
+        assert str(e.value) == "HashbableDummy name \"testing\" should be an instance of HashbableDummy"
+
+    def test_register_invalid_instance(self):
+        r = RegistryOrderedSet(HashbableDummy, "HashbableDummy")
+
+        n = NoName()
+
+        with pytest.raises(ValueError) as e:
+            r.register(n, "no-name")
+        assert str(e.value) == "HashbableDummy name \"no-name\" should be an instance of HashbableDummy"
+
+    def test_register_no_name_class_missing_name(self):
+        r = RegistryOrderedSet(NoName, "NoName")
+
+        n = NoName()
+
+        with pytest.raises(ValueError) as e:
+            r.register(n)
+        assert str(e.value) == "Name should be provided to register this kind of object"
+
+    def test_binary_ordering(self):
+        binary1 = DockerBinary("npm", "node1")
+        binary2 = DockerBinary("npm", "node2")
+        default_binary = DefaultBinary("npm", ["npm"])
+        binary4 = DockerBinary("npm", "node4")
+        binary_with_condition = DockerBinary("npm", "node5", condition="some-condition")
+
+        bins = (binary1, binary2, default_binary, binary4, binary_with_condition)
+
+        r = RegistryOrderedSet(Binary, "Binary")
+        for bin in bins:
+            r.register(bin)
+
+        assert r.all() == bins
+        npm_binaries = r.get("npm")
+
+        assert npm_binaries == bins


### PR DESCRIPTION
#141

This feature bring the ability to have the same command in different version inside the same project.

This add the `condition` parameter on binaries so you can restrict the availability of a command inside a given project directory or configuration option.

When a binary shim is invoked, it runs `ddb run <name>` under the hood. All Binaries matching this name with a condition defined will have their condition evaluated, and first condition returning True will be used to generate the effective command output. If no condition match, it will use the first of remaining Binary matching this name (without condition).

If no binary matching this name is finally found, it will invoke the command wrapped into $(ddb deactivate)/$(ddb activate) instruction, so the command run on the host system.