### PR TITLE
fix(shell): Fix drive case for default Windows `docker.path_mapping` (#159)

### DIFF
--- a/ddb/feature/docker/__init__.py
+++ b/ddb/feature/docker/__init__.py
@@ -181,6 +181,14 @@ class DockerFeature(Feature):
 
     @staticmethod
     def _configure_defaults_path_mapping(feature_config):
+        """
+        On windows, this generates a default path mapping matching docker-compose behavior when
+        COMPOSE_CONVERT_WINDOWS_PATHS=1 is enabled.
+
+        Drive letter should be lowercased to have the same behavior
+
+        https://github.com/docker/compose/blob/f1059d75edf76e8856469108997c15bb46a41777/compose/config/types.py#L123-L132
+        """
         path_mapping = feature_config.get('path_mapping')
         if path_mapping is None:
             path_mapping = {}
@@ -188,6 +196,7 @@ class DockerFeature(Feature):
                 raw = config.data.get('core.path.project_home')
                 mapped = re.sub(r"^([a-zA-Z]):", r"/\1", raw)
                 mapped = pathlib.Path(mapped).as_posix()
+                mapped = re.sub(r"(\/)(.)(\/.*)", lambda x: x.group(1) + x.group(2).lower() + x.group(3), mapped)
                 path_mapping[raw] = mapped
             feature_config['path_mapping'] = path_mapping
 


### PR DESCRIPTION
Close #159